### PR TITLE
[Fix] Set GLM lib instead of QGeometry classes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "tinyobjloader"]
 	path = third_party/tinyobjloader
 	url = https://github.com/syoyo/tinyobjloader
+[submodule "third_party/glm"]
+	path = third_party/glm
+	url = https://github.com/g-truc/glm

--- a/Arverne-Viewer.pro
+++ b/Arverne-Viewer.pro
@@ -17,12 +17,17 @@ TEMPLATE = app
 # deprecated API in order to know how to port your code away from it.
 DEFINES += QT_DEPRECATED_WARNINGS
 
+
 # You can also make your code fail to compile if you use deprecated APIs.
 # In order to do so, uncomment the following line.
 # You can also select to disable deprecated APIs only up to a certain version of Qt.
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
 CONFIG += c++11
+
+INCLUDEPATH += third_party/tinyobjloader
+INCLUDEPATH += third_party/glm
+
 
 SOURCES += \
         main.cpp \
@@ -67,7 +72,6 @@ HEADERS += \
     loader/Loader.hpp \
     loader/ObjLoader.hpp \
     renderer/Mesh.hpp \
-    third_party/tinyobjloader/tiny_obj_loader.h \
     renderer/texture/MaterialTexture.hpp \
     loader/ImageLoader.hpp \
     application/mainwindow.h \
@@ -76,6 +80,7 @@ HEADERS += \
     renderer/Model.hpp \
     renderer/Material.hpp \
     application/ModelManager.hpp
+
 
 
 # Default rules for deployment.

--- a/loader/ObjLoader.cpp
+++ b/loader/ObjLoader.cpp
@@ -1,11 +1,10 @@
 #include "ObjLoader.hpp"
 #include <algorithm>
-#include <QVector2D>
-#include <QVector3D>
-#include <QMap>
+#include <glm/vec2.hpp>
+#include <glm/vec3.hpp>
 
 #define TINYOBJLOADER_IMPLEMENTATION
-#include "third_party/tinyobjloader/tiny_obj_loader.h"
+#include "tiny_obj_loader.h"
 
 ObjLoader::ObjLoader(/* args */) : 
 Loader()
@@ -38,7 +37,7 @@ bool ObjLoader::load(const std::string& path,renderer::Model& scene)
     std::vector<renderer::Mesh> meshes;
 
     if (!err.empty()) {
-        qFatal("%s", err.data());
+        std::cout << err.data() << std::endl;
     }
 
     if (!ret) {
@@ -72,17 +71,17 @@ bool ObjLoader::load(const std::string& path,renderer::Model& scene)
                 if(idx.vertex_index > -1)
                 {
                     indexTemp = idx.vertex_index*3;
-                    vertex.pos = QVector3D(attrib.vertices[indexTemp], attrib.vertices[indexTemp+1], attrib.vertices[indexTemp+2]);
+                    vertex.pos = glm::vec3(attrib.vertices[indexTemp], attrib.vertices[indexTemp+1], attrib.vertices[indexTemp+2]);
                 }
                 if(idx.normal_index > -1)
                 {
                     indexTemp = idx.normal_index*3;
-                    vertex.normal = QVector3D(attrib.normals[indexTemp], attrib.normals[indexTemp+1], attrib.normals[indexTemp+2]);
+                    vertex.normal = glm::vec3(attrib.normals[indexTemp], attrib.normals[indexTemp+1], attrib.normals[indexTemp+2]);
                 }
                 if(idx.texcoord_index > -1)
                 {
                     indexTemp = idx.texcoord_index*2;
-                    vertex.texCoord = QVector2D(attrib.texcoords[indexTemp], attrib.texcoords[indexTemp+1]);
+                    vertex.texCoord = glm::vec2(attrib.texcoords[indexTemp], attrib.texcoords[indexTemp+1]);
                 }
 
 

--- a/renderer/Vertex.hpp
+++ b/renderer/Vertex.hpp
@@ -1,8 +1,8 @@
 #ifndef VERTEX_HPP
 #define VERTEX_HPP
 
-#include <QVector3D>
-#include <QVector2D>
+#include <glm/vec3.hpp>
+#include <glm/vec2.hpp>
 #include <vulkan/vulkan.h>
 #include <array>
 
@@ -12,10 +12,10 @@ namespace renderer
 
 struct Vertex
 {
-    QVector3D pos;
+    glm::vec3 pos;
     //QVector3D color;
-    QVector3D normal;
-    QVector2D texCoord;
+    glm::vec3 normal;
+    glm::vec2 texCoord;
 
 	static VkVertexInputBindingDescription getBindingDescription();
     static std::array<VkVertexInputAttributeDescription, 3> getAttributeDescriptions();

--- a/renderer/VulkanCore.hpp
+++ b/renderer/VulkanCore.hpp
@@ -4,7 +4,8 @@
 #include <iostream>
 #include <vulkan/vulkan.h>
 #include <vector>
-#include <QMatrix4x4>
+#include <glm/mat4x4.hpp>
+#include <glm/vec3.hpp>
 #include "DebugMessenger.hpp"
 #include "PhysicalDeviceProvider.hpp"
 #include "Swapchain.hpp"
@@ -14,13 +15,14 @@
 #include "camera/Camera.hpp"
 #include "Mesh.hpp"
 #include "Model.hpp"
+#include <QString>
 
 namespace renderer
 {
 
-#ifndef NDEBUG
-const bool ENABLE_VALIDATION_LAYERS = true;
-#else 
+#ifdef NDEBUG
+const bool ENABLE_VALIDATION_LAYERS = false;
+#else
 const bool ENABLE_VALIDATION_LAYERS = true;
 #endif
 
@@ -41,32 +43,10 @@ protected :
 
 	struct UniformBufferObject
 	{
-        QMatrix4x4 model;
-        QMatrix4x4 view;
-        QMatrix4x4 projection;
-        QVector3D lightPos;
-        std::array<float, 51> getConstData();
-        static constexpr uint32_t size();
-	};
-
-	const std::vector<Vertex> VERTICES =
-	{
-        {{-0.5f,-0.5f,0.0f}, {1.0f,0.0f,0.0f}, {0.0f, 0.0f}},
-        {{0.5f,-0.5f,0.0f}, {1.0f,1.0f,1.0f}, {1.0f, 0.0f}},
-        {{-0.5f,0.5f,0.0f}, {0.0f,0.0f,1.0f}, {0.0f,1.0f}},
-        {{0.5f,0.5f,0.0f}, {0.0f,1.0f,0.0f}, {1.0f, 1.0f}},
-
-        {{-0.5f,-0.5f,0.5f}, {1.0f,0.0f,0.0f}, {0.0f, 0.0f}},
-        {{0.5f,-0.5f,0.5f}, {1.0f,1.0f,1.0f}, {1.0f, 0.0f}},
-        {{-0.5f,0.5f,0.5f}, {0.0f,0.0f,1.0f}, {0.0f,1.0f}},
-        {{0.5f,0.5f,0.5f}, {0.0f,1.0f,0.0f}, {1.0f, 1.0f}},
-	};
-
-
-	const std::vector<uint16_t> VERTEX_INDICES =
-	{
-        0,1,2,1,3,2,
-        4,5,6,5,7,6
+        glm::mat4x4 model;
+        glm::mat4x4 view;
+        glm::mat4x4 projection;
+        glm::vec3 lightPos;
 	};
 
 

--- a/renderer/camera/ArcBallCamera.cpp
+++ b/renderer/camera/ArcBallCamera.cpp
@@ -1,17 +1,19 @@
 #include "ArcBallCamera.hpp"
-#include <QtMath>
+#include <glm/gtc/constants.hpp>
+#include <algorithm>
 
 
 namespace renderer
 {
 
+const float M_PI = glm::pi<float>();
 
 
 ArcBallCamera::ArcBallCamera():
     Camera(),
-    phi_(3*M_PI/4.0),
-    theta_(M_PI),
-    radius_(2.0f)
+    radius_(2.0f),
+    phi_(3.0f*M_PI/4.0f),
+    theta_(M_PI)
 {
     computePosition();
 }
@@ -49,7 +51,7 @@ float ArcBallCamera::getPhi() const
 
 void ArcBallCamera::setPhi(float phi)
 {
-    phi_ = std::max(std::min(static_cast<float>(M_PI-0.01), phi), 0.01f);
+    phi_ = std::max(std::min(static_cast<float>(M_PI-0.01f), phi), 0.01f);
     computePosition();
 }
 
@@ -74,7 +76,7 @@ void ArcBallCamera::setTheta(float theta)
 
 //------------------------------------------------------------------------------------------------------
 
-void ArcBallCamera::setCenter(const QVector3D &center)
+void ArcBallCamera::setCenter(const glm::vec3 &center)
 {
     Camera::setCenter(center);
     computePosition();
@@ -82,7 +84,7 @@ void ArcBallCamera::setCenter(const QVector3D &center)
 
 //------------------------------------------------------------------------------------------------------
 
-void ArcBallCamera::setPosition(const QVector3D &position)
+void ArcBallCamera::setPosition(const glm::vec3 &position)
 {
     Camera::setPosition(position);
     computePolar();
@@ -113,9 +115,9 @@ void ArcBallCamera::incrementRadius(float radiusStep)
 
 void ArcBallCamera::computePosition()
 {
-    position_.setX(radius_ * sin(phi_) * cos(theta_));
-    position_.setY(radius_ * sin(phi_) * sin(theta_));
-    position_.setZ(radius_ * cos(phi_));
+    position_.x = radius_ * sin(phi_) * cos(theta_);
+    position_.y =radius_ * sin(phi_) * sin(theta_);
+    position_.z =radius_ * cos(phi_);
 
     position_ += center_;
 }
@@ -124,9 +126,9 @@ void ArcBallCamera::computePosition()
 
 void ArcBallCamera::computePolar()
 {
-    radius_ = sqrt(pow(position_.x(), 2)+pow(position_.y(), 2)+pow(position_.z(), 2));
-    theta_ = atan(position_.y()/position_.x());
-    phi_ = atan((pow(position_.x(), 2)+pow(position_.y(), 2))/position_.z());
+    radius_ = sqrt(pow(position_.x, 2)+pow(position_.y, 2)+pow(position_.z, 2));
+    theta_ = atan(position_.y/position_.x);
+    phi_ = atan((pow(position_.x, 2)+pow(position_.y, 2))/position_.z);
 }
 
 

--- a/renderer/camera/ArcBallCamera.hpp
+++ b/renderer/camera/ArcBallCamera.hpp
@@ -21,8 +21,8 @@ public:
     ArcBallCamera();
     virtual ~ArcBallCamera() override;
 
-    virtual void setPosition(const QVector3D &position) override;
-    virtual void setCenter(const QVector3D &position) override;
+    virtual void setPosition(const glm::vec3 &position) override;
+    virtual void setCenter(const glm::vec3 &position) override;
 
     void incrementPhi(float phiStep);
     void incrementTheta(float thetaStep);

--- a/renderer/camera/Camera.cpp
+++ b/renderer/camera/Camera.cpp
@@ -4,28 +4,28 @@
 namespace renderer
 {
 
-const QVector3D& Camera::getPosition() const
+const glm::vec3& Camera::getPosition() const
 {
     return position_;
 }
 
 //------------------------------------------------------------------------------------------------------
 
-void Camera::setPosition(const QVector3D &position)
+void Camera::setPosition(const glm::vec3 &position)
 {
     position_ = position;
 }
 
 //------------------------------------------------------------------------------------------------------
 
-const QVector3D &Camera::getCenter() const
+const glm::vec3 &Camera::getCenter() const
 {
     return center_;
 }
 
 //------------------------------------------------------------------------------------------------------
 
-void Camera::setCenter(const QVector3D &center)
+void Camera::setCenter(const glm::vec3 &center)
 {
     center_ = center;
 }
@@ -50,14 +50,14 @@ Camera::~Camera()
 
 //------------------------------------------------------------------------------------------------------
 
-const QVector3D& Camera::getUp() const
+const glm::vec3& Camera::getUp() const
 {
     return up_;
 }
 
 //------------------------------------------------------------------------------------------------------
 
-void Camera::setUp(const QVector3D &up)
+void Camera::setUp(const glm::vec3 &up)
 {
     up_ = up;
 }

--- a/renderer/camera/Camera.hpp
+++ b/renderer/camera/Camera.hpp
@@ -1,7 +1,7 @@
 #ifndef CAMERA_HPP
 #define CAMERA_HPP
 
-#include <QVector3D>
+#include <glm/vec3.hpp>
 
 namespace renderer
 {
@@ -9,9 +9,9 @@ namespace renderer
 class Camera
 {
 protected:
-    QVector3D position_;
-    QVector3D center_; //Look at this point
-    QVector3D up_; //Defines the Up vector in world coordinates
+    glm::vec3 position_;
+    glm::vec3 center_; //Look at this point
+    glm::vec3 up_; //Defines the Up vector in world coordinates
     float fov_;
 
 public:
@@ -22,14 +22,14 @@ public:
     Camera();
     virtual ~Camera();
 
-    const QVector3D& getUp() const;
-    void setUp(const QVector3D &up);
+    const glm::vec3& getUp() const;
+    void setUp(const glm::vec3 &up);
     float getFov() const;
     void setFov(float fov);
-    const QVector3D& getPosition() const;
-    virtual void setPosition(const QVector3D &position);
-    const QVector3D& getCenter() const;
-    virtual void setCenter(const QVector3D &center);
+    const glm::vec3& getPosition() const;
+    virtual void setPosition(const glm::vec3 &position);
+    const glm::vec3& getCenter() const;
+    virtual void setCenter(const glm::vec3 &center);
 };
 
 }


### PR DESCRIPTION
Replaced all the calls to QVectors and QMatrices functions and replaced
the class with glm classes, it fixes problem of memory mapping during
the transfer of the uniforms data from RAM to GPU